### PR TITLE
Corrected VOR CDI needle deflection

### DIFF
--- a/instrument-panel/instruments/vor1.cpp
+++ b/instrument-panel/instruments/vor1.cpp
@@ -181,7 +181,7 @@ void vor1::update()
 
     // Calculate values
     compassAngle = -simVars->vor1Obs;
-    locAngle = -atan(simVars->vor1RadialError / 15.1); // Each dot is 2 degrees of radial error
+    locAngle = -atan(simVars->vor1RadialError / 15.0); // Each dot is 2 degrees of radial error
     slopeAngle = 50;
     toFromOn = simVars->vor1ToFrom;
     glideSlopeOn = simVars->vor1GlideSlopeFlag;

--- a/instrument-panel/instruments/vor1.cpp
+++ b/instrument-panel/instruments/vor1.cpp
@@ -180,14 +180,18 @@ void vor1::update()
 #endif
 
     // Calculate values
+    double radialError = simVars->vor1RadialError;
+    if (abs(radialError) > 90) { // Range: -180 to +179
+        if (radialError > 0) radialError = 180 - radialError; else radialError = -180 - radialError;
+    }     
     compassAngle = -simVars->vor1Obs;
-    locAngle = -atan(simVars->vor1RadialError / 15.0); // Each dot is 2 degrees of radial error
+    locAngle = -atan(radialError / 15.0); // Each dot is 2 degrees of radial error
     slopeAngle = 50;
     toFromOn = simVars->vor1ToFrom;
     glideSlopeOn = simVars->vor1GlideSlopeFlag;
 
-    if (abs(locAngle) > 50) {
-        if (locAngle > 0) locAngle = 50; else locAngle = -50;
+    if (abs(locAngle) > (35 * DegreesToRadians)) {
+        if (locAngle > 0) locAngle = 35 * DegreesToRadians; else locAngle = -35 * DegreesToRadians;
     }
 
     slopeAngle = simVars->vor1GlideSlopeError * 25.0;

--- a/instrument-panel/instruments/vor1.cpp
+++ b/instrument-panel/instruments/vor1.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <math.h>
 #include "vor1.h"
 #include "simvars.h"
 #include "knobs.h"
@@ -131,7 +132,7 @@ void vor1::render()
     }
 
     // Add locator needle
-    al_draw_scaled_rotated_bitmap(bitmaps[7], 15, 140, 400 * scaleFactor, 140 * scaleFactor, scaleFactor, scaleFactor, locAngle * DegreesToRadians, 0);
+    al_draw_scaled_rotated_bitmap(bitmaps[7], 15, 140, 400 * scaleFactor, 140 * scaleFactor, scaleFactor, scaleFactor, locAngle, 0);
 
     // Add glide slope needle
     al_draw_scaled_rotated_bitmap(bitmaps[8], 140, 15, 140 * scaleFactor, 400 * scaleFactor, scaleFactor, scaleFactor, slopeAngle * DegreesToRadians, 0);
@@ -180,7 +181,7 @@ void vor1::update()
 
     // Calculate values
     compassAngle = -simVars->vor1Obs;
-    locAngle = -simVars->vor1RadialError * 15.0;
+    locAngle = -atan(simVars->vor1RadialError / 15.1); // Each dot is 2 degrees of radial error
     slopeAngle = 50;
     toFromOn = simVars->vor1ToFrom;
     glideSlopeOn = simVars->vor1GlideSlopeFlag;

--- a/instrument-panel/instruments/vor2.cpp
+++ b/instrument-panel/instruments/vor2.cpp
@@ -159,12 +159,16 @@ void vor2::update()
 #endif
 
     // Calculate values
+    double radialError = simVars->vor2RadialError;
+    if (abs(radialError) > 90) { // Range: -180 to +179
+        if (radialError > 0) radialError = 180 - radialError; else radialError = -180 - radialError;
+    }    
     compassAngle = -simVars->vor2Obs;
-    locAngle = -simVars->vor2RadialError * 2.5;
+    locAngle = -radialError * 2.5;
     toFromOn = simVars->vor2ToFrom;
 
-    if (abs(locAngle) > 50) {
-        if (locAngle > 0) locAngle = 50; else locAngle = -50;
+    if (abs(locAngle) > 35) {
+        if (locAngle > 0) locAngle = 35; else locAngle = -35;
     }
 }
 

--- a/instrument-panel/instruments/vor2.cpp
+++ b/instrument-panel/instruments/vor2.cpp
@@ -160,7 +160,7 @@ void vor2::update()
 
     // Calculate values
     compassAngle = -simVars->vor2Obs;
-    locAngle = -simVars->vor2RadialError * 15.0;
+    locAngle = -simVars->vor2RadialError * 2.5;
     toFromOn = simVars->vor2ToFrom;
 
     if (abs(locAngle) > 50) {


### PR DESCRIPTION
Corrected the VOR CDI needle behavior to align with the following Wikipedia except:

> The deflection of the needle is proportional to the course deviation, but sensitivity and deflection vary depending on the system being used:
>  - When used with a VOR or VORTAC, the instrument can be referred to as an "omni bearing indicator" ("OBI").[2] The courseline is selected by turning an "omni bearing selector" or "OBS" knob usually located in the lower left of the indicator. It then shows the number of degrees deviation between the aircraft's current position and the "radial" line emanating from the signal source at the given bearing. This can be used to find and follow the desired radial. Deflection is 10° deviation at full scale (each side), with each dot on the CDI representing 2°. (See Using a VOR for usage during flight.)

Changed instruments `vor1` and `vor2`:
- Changed the needle behavior so the _radial error_ from the MS2020 is displayed in accordance to the CDI 2° reference dots
- Added corrected behavior for displaying the needle when using the FROM radials 
- Changed the limits of the CDI needle swing to mimic the behavior of actual devices and MS2020 

_Note: The FS2020 VOR2 CDI behavior does not align with the spec where each dot on the CDI represents 2°, however, the new behavior of `vor2`  does use the spec._