### PR TITLE
Fix inverted amp meter values

### DIFF
--- a/instrument-panel/instruments/vac.cpp
+++ b/instrument-panel/instruments/vac.cpp
@@ -115,8 +115,8 @@ void vac::update()
     else if (vacAngle > 60) {
         vacAngle = 60;
     }
-
-    ampAngle = 119 + (simVars->batteryLoad + 60);
+    // MSFS seems to have a bug in the battery load; the sign must be reversed.
+    ampAngle = 119 + (-simVars->batteryLoad + 60);
     if (ampAngle < 119) {
         ampAngle = 119;
     }


### PR DESCRIPTION
The "battery load" sim var uses positive values for "loads" and negative values when "charging".  

- Inverted the sign of the sim var when computing the amp indicator's needle angle.  

Closes #28